### PR TITLE
Fix bug of DidYouMean::Levenshtein#min3.

### DIFF
--- a/lib/did_you_mean/levenshtein.rb
+++ b/lib/did_you_mean/levenshtein.rb
@@ -35,7 +35,7 @@ module DidYouMean
     def min3(a, b, c) # :nodoc:
       if a < b && a < c
         a
-      elsif b < a && b < c
+      elsif b < c
         b
       else
         c


### PR DESCRIPTION
Hi!
After I closed #1, I found a bug in `DidYouMean::Levenshtein#min3`.
When `a == b < c`, `#min3` return `c`.
