### PR TITLE
Add RubyGems version badge in README [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# did_you_mean [![Build Status](https://travis-ci.org/yuki24/did_you_mean.svg?branch=master)](https://travis-ci.org/yuki24/did_you_mean)
+# did_you_mean [![Gem Version](https://badge.fury.io/rb/did_you_mean.svg)](http://badge.fury.io/rb/did_you_mean) [![Build Status](https://travis-ci.org/yuki24/did_you_mean.svg?branch=master)](https://travis-ci.org/yuki24/did_you_mean)
 
 'Did you mean?' experience in Ruby. No, Really.
 


### PR DESCRIPTION
Add RubyGems version badge.
Badge can show 'did_you_mean' latest version information.
Badge is link to RubyGems 'did_you_mean' page.
I think "RubyGems version badge" is useful for visitors.
