### PR TITLE
Levenshtein Refactoring

### DIFF
--- a/lib/did_you_mean/levenshtein.rb
+++ b/lib/did_you_mean/levenshtein.rb
@@ -13,12 +13,11 @@ module DidYouMean
 
       str1.each_char.with_index(1) do |char1, i|
         str2.each_char.with_index do |char2, j|
-          cost = (char1 == char2) ? 0 : 1
-          x = min3(
-            d[j+1] + 1, # insertion
-            i + 1,      # deletion
-            d[j] + cost # substitution
-          )
+          insertion_cost    = d[j+1] + 1
+          deletion_cost     = i + 1
+          substitution_cost = d[j] + ((char1 == char2) ? 0 : 1)
+
+          x = [insertion_cost, deletion_cost, substitution_cost].min
           d[j] = i
           i = x
         end
@@ -28,18 +27,5 @@ module DidYouMean
       x
     end
     module_function :distance
-
-    private
-
-    def min3(a, b, c) # :nodoc:
-      if a < b && a < c
-        a
-      elsif b < c
-        b
-      else
-        c
-      end
-    end
-    module_function :min3
   end
 end


### PR DESCRIPTION
I refactored a bit the module which computes the Levenshtein Distance :heart::
- Better clarity on some variable names
- Inline `min` function

On the other hand using an existing gem could make sense. [This one](https://github.com/dbalatero/levenshtein-ffi) uses FFI under the hood, thus I am not entirely sure if there might be some compatibility issue. It has been tested against:

```
MRI 1.9.2
MRI 1.9.3
MRI 2.0.0
Rubinius (1.9 mode)
```

It seems significantly faster, though.
