### PR TITLE
Whitelisting safe_constantize (ActiveSupport::Inflector) method

### DIFF
--- a/test/name_error_extension_test.rb
+++ b/test/name_error_extension_test.rb
@@ -21,4 +21,26 @@ class NameErrorExtensionTest < Minitest::Test
     assert_match "Y U SO SLOW?", @error.to_s
     assert_match "Y U SO SLOW?", @error.message
   end
+
+  def test_whitelisted_message?
+    @error = safe_constantize
+    assert @error.to_s =~ /doesnt_exist/
+    assert @error.message =~ /doesnt_exist/
+  end
+
+  def test_note_whitelisted_message?
+    @error = not_safe_constantize
+    assert_match "Y U SO SLOW?", @error.to_s
+    assert_match "Y U SO SLOW?", @error.message
+  end
+
+  private
+
+  def safe_constantize
+    assert_raises(NAME_ERROR){ doesnt_exist }
+  end
+
+  def not_safe_constantize
+    assert_raises(NAME_ERROR){ doesnt_exist }
+  end
 end


### PR DESCRIPTION
In regards to issue #19, whitelisting safe_constantize (ActiveSupport::Inflector) from calling did_you_mean if the calling method is a known OK method.
