### PR TITLE
Suggest method signatures on wrong number of arguments

### DIFF
--- a/lib/did_you_mean/experimental.rb
+++ b/lib/did_you_mean/experimental.rb
@@ -1,2 +1,3 @@
 require 'did_you_mean/experimental/initializer_name_correction'
 require 'did_you_mean/experimental/ivar_name_correction'
+require 'did_you_mean/experimental/argument_error_correction'

--- a/lib/did_you_mean/experimental/argument_error_correction.rb
+++ b/lib/did_you_mean/experimental/argument_error_correction.rb
@@ -1,0 +1,64 @@
+require "rdoc/ri/driver"
+require "tempfile"
+
+module DidYouMean
+  module Experimental #:nodoc:
+    module ArgumentErrorCorrectable
+      # TODO: support ArgumentError#receiver to get fast method signatures.
+      TRACE = TracePoint.trace(:raise) do |tp|
+        e = tp.raised_exception
+        if e.is_a?(ArgumentError) &&
+           /wrong number of arguments/.match(e.original_message)
+          e.instance_variable_set(:@_receiver, tp.self)
+          e.instance_variable_set(:@_method_id, tp.method_id)
+        end
+      end
+
+      def original_message
+        method(:to_s).super_method.call
+      end
+
+      def to_s
+        msg = super.dup
+
+        corrections = signatures
+        if !corrections.empty?
+          msg << DidYouMean.formatter.message_for(corrections)
+        end
+
+        msg
+      rescue
+        super
+      end
+
+      def signatures
+        res = []
+        if _receiver && _method_id
+          if _method_id == :initialize
+            m = "#{_receiver.class}.new"
+          else
+            m = _receiver.method(_method_id).to_s.gsub(/#<Method: ([^>]+)>/) { $1 }
+          end
+
+          Tempfile.open("ri") do |f|
+            begin
+              $stdout = f
+              # TODO: Return string directly.
+              RDoc::RI::Driver.new(use_stdout: true, names: [m]).run
+            ensure
+              $stdout = STDOUT
+            end
+            f.rewind
+            if s = /^-+$(.*)^-+$/m.match(f.read)[1].chomp
+              res = s.gsub(/\s*->\s*.*$/, '').split(/\n/)
+            end
+          end
+        end
+        return res
+      end
+    end
+
+    ::ArgumentError.send(:attr_reader, :_receiver, :_method_id)
+    ::ArgumentError.prepend ArgumentErrorCorrectable
+  end
+end


### PR DESCRIPTION
I want to add suggestion on wrong number of arguments.
I added experimental class with refering experimental/ivar_name_correction.

```ruby
require 'did_you_mean/experimental'

Dir.glob('*', 0, 1, 2)
# test.rb:n:in `glob': wrong number of arguments (given 4, expected 1..2) (ArgumentError)
# Did you mean?
#                  Dir.glob( pattern, [flags], [base: path] )
#                  Dir.glob( pattern, [flags], [base: path] ) { |filename| block }

Array.new(3, "foo", "bar")
# test.rb:n:in `initialize': wrong number of arguments (given 3, expected 0..2) (ArgumentError)
# Did you mean?
#                  Array.new(size=0, default=nil)
#                  Array.new(array)
#                  Array.new(size) {|index| block }

a = [1,2,3]
p a.slice(1, 2, 3)
# test.rb:n:in `slice': wrong number of arguments (given 3, expected 1..2) (ArgumentError)
# Did you mean?
#                  ary.slice(index)
#                  ary.slice(start, length)
#                  ary.slice(range)
```