### PR TITLE
Extract accuracy/explore/memory menchmark tasks out of each build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,6 @@ sudo:     false
 before_install:
   - gem install bundler
 
-after_success:
-  - bundle exec rake test:accuracy
-  - bundle exec rake test:explore
-  - bundle exec rake benchmark:memory
-
 rvm:
   - 2.5.3
   - 2.6.0
@@ -19,6 +14,13 @@ rvm:
   - jruby-head
 
 matrix:
+  include:
+    - rvm: 2.6.0
+      script:
+        - bundle exec rake test:accuracy
+        - bundle exec rake test:explore
+        - bundle exec rake benchmark:memory
+
   allow_failures:
     - rvm: jruby-9.2.5.0
     - rvm: jruby-head


### PR DESCRIPTION
We don't have to run tasks like `test:accuracy` or `test:explore` in each build. The accuracy of the spell checker is independent of language runtime and the `benchmark:memory` is irrelevant in JRuby. We can just use the most recent Ruby to run these jobs.