### PR TITLE
Fix up relative file paths for yml files

### DIFF
--- a/documentation/tree_spell_algorithm.md
+++ b/documentation/tree_spell_algorithm.md
@@ -1,6 +1,6 @@
 # TreeSpellChecker Algorithm
 ## Overview
-The algorithm is designed to work on a dicionary that has a rooted tree structure.
+The algorithm is designed to work on a dictionary that has a rooted tree structure.
 
 The algorithm treats the problem as a hidden state system, which tries to identify the true state of the input. Due to typographical errors, the state of the input is a hidden version of the true system state.  Each word in the dictionary is mapped to a multi-dimensional state, with the first dimension being being the root, the second dimension being the next branch, and so on.  Each dimension is discrete with a finite number of elements.  The first dimension corresponds to the root, so only has one element.
 

--- a/test/tree_spell/test_explore.rb
+++ b/test/tree_spell/test_explore.rb
@@ -5,8 +5,8 @@ require_relative 'human_typo'
 
 # statistical tests on tree_spell algorithms
 class ExploreTest < Test::Unit::TestCase
-  MINI_DIRECTORIES = YAML.load_file('test/fixtures/mini_dir.yml')
-  RSPEC_DIRECTORIES = YAML.load_file('test/fixtures/rspec_dir.yml')
+  MINI_DIRECTORIES = YAML.load_file(File.expand_path('../fixtures/mini_dir.yml', __dir__))
+  RSPEC_DIRECTORIES = YAML.load_file(File.expand_path('../fixtures/rspec_dir.yml', __dir__))
 
   def test_checkers_with_many_typos_on_mini
     n_repeat = 10_000

--- a/test/tree_spell_checker_test.rb
+++ b/test/tree_spell_checker_test.rb
@@ -1,10 +1,10 @@
-require 'test_helper'
+require 'helper'
 require 'set'
 require 'yaml'
 
-class TreeSpellCheckerTest  < Minitest::Test
-  MINI_DIRECTORIES = YAML.load_file('test/fixtures/mini_dir.yml')
-  RSPEC_DIRECTORIES = YAML.load_file('test/fixtures/rspec_dir.yml')
+class TreeSpellCheckerTest < Test::Unit::TestCase
+  MINI_DIRECTORIES = YAML.load_file(File.expand_path('fixtures/mini_dir.yml', __dir__))
+  RSPEC_DIRECTORIES = YAML.load_file(File.expand_path('fixtures/rspec_dir.yml', __dir__))
 
   def setup
     @dictionary = 


### PR DESCRIPTION
When loaded into the Ruby repo, the place the test files are run from can change and it ends up messing up the file path. This changes it to be relative so that it maintains the correct linking.