### PR TITLE
Fixes for promotion to default gem

### DIFF
--- a/lib/did_you_mean.rb
+++ b/lib/did_you_mean.rb
@@ -1,13 +1,13 @@
-require "did_you_mean/version"
-require "did_you_mean/core_ext/name_error"
+require_relative "did_you_mean/version"
+require_relative "did_you_mean/core_ext/name_error"
 
-require "did_you_mean/spell_checker"
-require 'did_you_mean/spell_checkers/name_error_checkers'
-require 'did_you_mean/spell_checkers/method_name_checker'
-require 'did_you_mean/spell_checkers/key_error_checker'
-require 'did_you_mean/spell_checkers/null_checker'
-require 'did_you_mean/formatters/plain_formatter'
-require 'did_you_mean/tree_spell_checker'
+require_relative "did_you_mean/spell_checker"
+require_relative 'did_you_mean/spell_checkers/name_error_checkers'
+require_relative 'did_you_mean/spell_checkers/method_name_checker'
+require_relative 'did_you_mean/spell_checkers/key_error_checker'
+require_relative 'did_you_mean/spell_checkers/null_checker'
+require_relative 'did_you_mean/formatters/plain_formatter'
+require_relative 'did_you_mean/tree_spell_checker'
 
 # The +DidYouMean+ gem adds functionality to suggest possible method/class
 # names upon errors such as +NameError+ and +NoMethodError+. In Ruby 2.3 or

--- a/lib/did_you_mean/experimental.rb
+++ b/lib/did_you_mean/experimental.rb
@@ -1,2 +1,2 @@
-require 'did_you_mean/experimental/initializer_name_correction'
-require 'did_you_mean/experimental/ivar_name_correction'
+require_relative 'experimental/initializer_name_correction'
+require_relative 'experimental/ivar_name_correction'

--- a/lib/did_you_mean/experimental/initializer_name_correction.rb
+++ b/lib/did_you_mean/experimental/initializer_name_correction.rb
@@ -1,6 +1,6 @@
 # frozen-string-literal: true
 
-require 'did_you_mean/levenshtein'
+require_relative '../levenshtein'
 
 module DidYouMean
   module Experimental

--- a/lib/did_you_mean/experimental/ivar_name_correction.rb
+++ b/lib/did_you_mean/experimental/ivar_name_correction.rb
@@ -1,6 +1,6 @@
 # frozen-string-literal: true
 
-require 'did_you_mean'
+require_relative '../../did_you_mean'
 
 module DidYouMean
   module Experimental #:nodoc:

--- a/lib/did_you_mean/spell_checker.rb
+++ b/lib/did_you_mean/spell_checker.rb
@@ -1,7 +1,7 @@
 # frozen-string-literal: true
 
-require "did_you_mean/levenshtein"
-require "did_you_mean/jaro_winkler"
+require_relative "levenshtein"
+require_relative "jaro_winkler"
 
 module DidYouMean
   class SpellChecker

--- a/lib/did_you_mean/spell_checkers/key_error_checker.rb
+++ b/lib/did_you_mean/spell_checkers/key_error_checker.rb
@@ -1,4 +1,4 @@
-require "did_you_mean/spell_checker"
+require_relative "../spell_checker"
 
 module DidYouMean
   class KeyErrorChecker

--- a/lib/did_you_mean/spell_checkers/method_name_checker.rb
+++ b/lib/did_you_mean/spell_checkers/method_name_checker.rb
@@ -1,4 +1,4 @@
-require "did_you_mean/spell_checker"
+require_relative "../spell_checker"
 
 module DidYouMean
   class MethodNameChecker

--- a/lib/did_you_mean/spell_checkers/name_error_checkers.rb
+++ b/lib/did_you_mean/spell_checkers/name_error_checkers.rb
@@ -1,5 +1,5 @@
-require 'did_you_mean/spell_checkers/name_error_checkers/class_name_checker'
-require 'did_you_mean/spell_checkers/name_error_checkers/variable_name_checker'
+require_relative 'name_error_checkers/class_name_checker'
+require_relative 'name_error_checkers/variable_name_checker'
 
 module DidYouMean
   class << (NameErrorCheckers = Object.new)

--- a/lib/did_you_mean/spell_checkers/name_error_checkers/class_name_checker.rb
+++ b/lib/did_you_mean/spell_checkers/name_error_checkers/class_name_checker.rb
@@ -1,6 +1,7 @@
 # frozen-string-literal: true
+
 require 'delegate'
-require "did_you_mean/spell_checker"
+require_relative "../../spell_checker"
 
 module DidYouMean
   class ClassNameChecker

--- a/lib/did_you_mean/spell_checkers/name_error_checkers/variable_name_checker.rb
+++ b/lib/did_you_mean/spell_checkers/name_error_checkers/variable_name_checker.rb
@@ -1,6 +1,6 @@
 # frozen-string-literal: true
 
-require "did_you_mean/spell_checker"
+require_relative "../../spell_checker"
 
 module DidYouMean
   class VariableNameChecker

--- a/lib/did_you_mean/verbose.rb
+++ b/lib/did_you_mean/verbose.rb
@@ -1,4 +1,4 @@
-require 'did_you_mean'
-require 'did_you_mean/formatters/verbose_formatter'
+require_relative '../did_you_mean'
+require_relative 'formatters/verbose_formatter'
 
 DidYouMean.formatter = DidYouMean::VerboseFormatter.new

--- a/test/core_ext/test_name_error_extension.rb
+++ b/test/core_ext/test_name_error_extension.rb
@@ -11,7 +11,7 @@ class NameErrorExtensionTest < Test::Unit::TestCase
   def setup
     @org, SPELL_CHECKERS['NameError'] = SPELL_CHECKERS['NameError'], TestSpellChecker
 
-    @error = assert_raises(NameError){ doesnt_exist }
+    @error = assert_raise(NameError){ doesnt_exist }
   end
 
   def teardown
@@ -24,7 +24,7 @@ class NameErrorExtensionTest < Test::Unit::TestCase
   end
 
   def test_to_s_does_not_make_disruptive_changes_to_error_message
-    error = assert_raises(NameError) do
+    error = assert_raise(NameError) do
       raise NameError, "uninitialized constant Object"
     end
 

--- a/test/experimental/test_method_name_checker.rb
+++ b/test/experimental/test_method_name_checker.rb
@@ -4,7 +4,7 @@ class ExperimentalMethodNameCorrectionTest < Test::Unit::TestCase
   def test_corrects_incorrect_ivar_name
     @number = 1
     @nubmer = nil
-    error = assert_raises(NoMethodError) { @nubmer.zero? }
+    error = assert_raise(NoMethodError) { @nubmer.zero? }
     remove_instance_variable :@nubmer
 
     assert_correction :@number, error.corrections

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,11 @@
 require 'test/unit'
-require 'did_you_mean'
+
+roots = [
+  File.expand_path('../lib/did_you_mean', __dir__), # source
+  File.expand_path('../../lib/did_you_mean', __dir__) # ruby core
+]
+  
+require_relative roots.detect { |file| File.file?("#{file}.rb") }
 
 puts "DidYouMean version: #{DidYouMean::VERSION}"
 

--- a/test/spell_checking/test_class_name_check.rb
+++ b/test/spell_checking/test_class_name_check.rb
@@ -29,42 +29,42 @@ end
 
 class ClassNameCheckTest < Test::Unit::TestCase
   def test_corrections
-    error = assert_raises(NameError) { ::Bo0k }
+    error = assert_raise(NameError) { ::Bo0k }
     assert_correction "Book", error.corrections
   end
 
   def test_corrections_include_case_specific_class_name
-    error = assert_raises(NameError) { ::Acronym }
+    error = assert_raise(NameError) { ::Acronym }
     assert_correction "ACRONYM", error.corrections
   end
 
   def test_corrections_include_top_level_class_name
-    error = assert_raises(NameError) { Project.bo0k }
+    error = assert_raise(NameError) { Project.bo0k }
     assert_correction "Book", error.corrections
   end
 
   def test_names_in_corrections_have_namespaces
-    error = assert_raises(NameError) { ::Book::TableofContents }
+    error = assert_raise(NameError) { ::Book::TableofContents }
     assert_correction "Book::TableOfContents", error.corrections
   end
 
   def test_corrections_candidates_for_names_in_upper_level_scopes
-    error = assert_raises(NameError) { Book::Page.tableof_contents }
+    error = assert_raise(NameError) { Book::Page.tableof_contents }
     assert_correction "Book::TableOfContents", error.corrections
   end
 
   def test_corrections_should_work_from_within_instance_method
-    error = assert_raises(NameError) { ::Book.new.tableof_contents }
+    error = assert_raise(NameError) { ::Book.new.tableof_contents }
     assert_correction "Book::TableOfContents", error.corrections
   end
 
   def test_corrections_should_work_from_within_instance_method_on_nested_class
-    error = assert_raises(NameError) { ::Book::Page.new.tableof_contents }
+    error = assert_raise(NameError) { ::Book::Page.new.tableof_contents }
     assert_correction "Book::TableOfContents", error.corrections
   end
 
   def test_does_not_suggest_user_input
-    error = assert_raises(NameError) { ::Book::Cover }
+    error = assert_raise(NameError) { ::Book::Cover }
 
     # This is a weird require, but in a multi-threaded condition, a constant may
     # be loaded between when a NameError occurred and when the spell checker

--- a/test/spell_checking/test_key_name_check.rb
+++ b/test/spell_checking/test_key_name_check.rb
@@ -4,11 +4,11 @@ class KeyNameCheckTest < Test::Unit::TestCase
   def test_corrects_hash_key_name_with_fetch
     hash = { "foo" => 1, bar: 2 }
 
-    error = assert_raises(KeyError) { hash.fetch(:bax) }
+    error = assert_raise(KeyError) { hash.fetch(:bax) }
     assert_correction ":bar", error.corrections
     assert_match "Did you mean?  :bar", error.to_s
 
-    error = assert_raises(KeyError) { hash.fetch("fooo") }
+    error = assert_raise(KeyError) { hash.fetch("fooo") }
     assert_correction %("foo"), error.corrections
     assert_match %(Did you mean?  "foo"), error.to_s
   end
@@ -16,17 +16,17 @@ class KeyNameCheckTest < Test::Unit::TestCase
   def test_corrects_hash_key_name_with_fetch_values
     hash = { "foo" => 1, bar: 2 }
 
-    error = assert_raises(KeyError) { hash.fetch_values("foo", :bar, :bax) }
+    error = assert_raise(KeyError) { hash.fetch_values("foo", :bar, :bax) }
     assert_correction ":bar", error.corrections
     assert_match "Did you mean?  :bar", error.to_s
 
-    error = assert_raises(KeyError) { hash.fetch_values("foo", :bar, "fooo") }
+    error = assert_raise(KeyError) { hash.fetch_values("foo", :bar, "fooo") }
     assert_correction %("foo"), error.corrections
     assert_match %(Did you mean?  "foo"), error.to_s
   end
 
   def test_corrects_sprintf_key_name
-    error = assert_raises(KeyError) { sprintf("%<foo>d", {fooo: 1}) }
+    error = assert_raise(KeyError) { sprintf("%<foo>d", {fooo: 1}) }
     assert_correction ":fooo", error.corrections
     assert_match "Did you mean?  :fooo", error.to_s
   end
@@ -34,7 +34,7 @@ class KeyNameCheckTest < Test::Unit::TestCase
   def test_corrects_env_key_name
     ENV["FOO"] = "1"
     ENV["BAR"] = "2"
-    error = assert_raises(KeyError) { ENV.fetch("BAX") }
+    error = assert_raise(KeyError) { ENV.fetch("BAX") }
     assert_correction %("BAR"), error.corrections
     assert_match %(Did you mean?  "BAR"), error.to_s
   ensure

--- a/test/spell_checking/test_method_name_check.rb
+++ b/test/spell_checking/test_method_name_check.rb
@@ -36,50 +36,50 @@ class MethodNameCheckTest < Test::Unit::TestCase
   end
 
   def test_corrections_include_instance_method
-    error = assert_raises(NoMethodError){ @user.flrst_name }
+    error = assert_raise(NoMethodError){ @user.flrst_name }
 
     assert_correction :first_name, error.corrections
     assert_match "Did you mean?  first_name",  error.to_s
   end
 
   def test_corrections_include_private_method
-    error = assert_raises(NoMethodError){ @user.friend }
+    error = assert_raise(NoMethodError){ @user.friend }
 
     assert_correction :friends, error.corrections
     assert_match "Did you mean?  friends", error.to_s
   end
 
   def test_corrections_include_method_from_module
-    error = assert_raises(NoMethodError){ @user.fr0m_module }
+    error = assert_raise(NoMethodError){ @user.fr0m_module }
 
     assert_correction :from_module, error.corrections
     assert_match "Did you mean?  from_module", error.to_s
   end
 
   def test_corrections_include_class_method
-    error = assert_raises(NoMethodError){ User.l0ad }
+    error = assert_raise(NoMethodError){ User.l0ad }
 
     assert_correction :load, error.corrections
     assert_match "Did you mean?  load", error.to_s
   end
 
   def test_private_methods_should_not_be_suggested
-    error = assert_raises(NoMethodError){ User.new.the_protected_method }
+    error = assert_raise(NoMethodError){ User.new.the_protected_method }
     refute_includes error.corrections, :the_protected_method
 
-    error = assert_raises(NoMethodError){ User.new.the_private_method }
+    error = assert_raise(NoMethodError){ User.new.the_private_method }
     refute_includes error.corrections, :the_private_method
   end
 
   def test_corrections_when_private_method_is_called_with_args
-    error = assert_raises(NoMethodError){ @user.call_incorrect_private_method }
+    error = assert_raise(NoMethodError){ @user.call_incorrect_private_method }
 
     assert_correction :raise, error.corrections
     assert_match "Did you mean?  raise", error.to_s
   end
 
   def test_exclude_methods_on_nil
-    error = assert_raises(NoMethodError){ nil.map }
+    error = assert_raise(NoMethodError){ nil.map }
     assert_empty error.corrections
   end
 
@@ -87,14 +87,14 @@ class MethodNameCheckTest < Test::Unit::TestCase
     def nil.empty?
     end
 
-    error = assert_raises(NoMethodError){ nil.empty }
+    error = assert_raise(NoMethodError){ nil.empty }
     assert_correction :empty?, error.corrections
   ensure
     NilClass.class_eval { undef empty? }
   end
 
   def test_does_not_append_suggestions_twice
-    error = assert_raises NoMethodError do
+    error = assert_raise NoMethodError do
       begin
         @user.firstname
       rescue NoMethodError => e
@@ -106,7 +106,7 @@ class MethodNameCheckTest < Test::Unit::TestCase
   end
 
   def test_does_not_append_suggestions_three_times
-    error = assert_raises NoMethodError do
+    error = assert_raise NoMethodError do
       begin
         @user.raise_no_method_error
       rescue NoMethodError => e
@@ -118,7 +118,7 @@ class MethodNameCheckTest < Test::Unit::TestCase
   end
 
   def test_suggests_corrections_on_nested_error
-    error = assert_raises NoMethodError do
+    error = assert_raise NoMethodError do
       begin
         @user.firstname
       rescue NoMethodError
@@ -130,7 +130,7 @@ class MethodNameCheckTest < Test::Unit::TestCase
   end
 
   def test_suggests_yield
-    error = assert_raises(NoMethodError) { yeild(1) }
+    error = assert_raise(NoMethodError) { yeild(1) }
 
     assert_correction :yield, error.corrections
     assert_match "Did you mean?  yield", error.to_s

--- a/test/spell_checking/test_uncorrectable_name_check.rb
+++ b/test/spell_checking/test_uncorrectable_name_check.rb
@@ -4,7 +4,7 @@ class UncorrectableNameCheckTest < Test::Unit::TestCase
   class FirstNameError < NameError; end
 
   def setup
-    @error = assert_raises(FirstNameError) do
+    @error = assert_raise(FirstNameError) do
       raise FirstNameError, "Other name error"
     end
   end

--- a/test/spell_checking/test_variable_name_check.rb
+++ b/test/spell_checking/test_variable_name_check.rb
@@ -27,7 +27,7 @@ class VariableNameCheckTest < Test::Unit::TestCase
   end
 
   def test_corrections_include_instance_method
-    error = assert_raises(NameError) do
+    error = assert_raise(NameError) do
       @user.instance_eval { flrst_name }
     end
 
@@ -41,7 +41,7 @@ class VariableNameCheckTest < Test::Unit::TestCase
   end
 
   def test_corrections_include_method_from_module
-    error = assert_raises(NameError) do
+    error = assert_raise(NameError) do
       @user.instance_eval { fr0m_module }
     end
 
@@ -52,7 +52,7 @@ class VariableNameCheckTest < Test::Unit::TestCase
   def test_corrections_include_local_variable_name
     if RUBY_ENGINE != "jruby"
       person = person = nil
-      error = (eprson rescue $!) # Do not use @assert_raises here as it changes a scope.
+      error = (eprson rescue $!) # Do not use @assert_raise here as it changes a scope.
 
       assert_correction :person, error.corrections
       assert_match "Did you mean?  person", error.to_s
@@ -62,19 +62,19 @@ class VariableNameCheckTest < Test::Unit::TestCase
   def test_corrections_include_ruby_predefined_objects
     some_var = nil
 
-    false_error = assert_raises(NameError) do
+    false_error = assert_raise(NameError) do
       some_var = fals
     end
 
-    true_error = assert_raises(NameError) do
+    true_error = assert_raise(NameError) do
       some_var = treu
     end
 
-    nil_error = assert_raises(NameError) do
+    nil_error = assert_raise(NameError) do
       some_var = nul
     end
 
-    file_error = assert_raises(NameError) do
+    file_error = assert_raise(NameError) do
       __FIEL__
     end
 
@@ -92,21 +92,21 @@ class VariableNameCheckTest < Test::Unit::TestCase
   end
 
   def test_suggests_yield
-    error = assert_raises(NameError) { yeild }
+    error = assert_raise(NameError) { yeild }
 
     assert_correction :yield, error.corrections
     assert_match "Did you mean?  yield", error.to_s
   end
 
   def test_corrections_include_instance_variable_name
-    error = assert_raises(NameError){ @user.to_s }
+    error = assert_raise(NameError){ @user.to_s }
 
     assert_correction :@email_address, error.corrections
     assert_match "Did you mean?  @email_address", error.to_s
   end
 
   def test_corrections_include_private_method
-    error = assert_raises(NameError) do
+    error = assert_raise(NameError) do
       @user.instance_eval { cia_code_name }
     end
 
@@ -117,7 +117,7 @@ class VariableNameCheckTest < Test::Unit::TestCase
   @@does_exist = true
 
   def test_corrections_include_class_variable_name
-    error = assert_raises(NameError){ @@doesnt_exist }
+    error = assert_raise(NameError){ @@doesnt_exist }
 
     assert_correction :@@does_exist, error.corrections
     assert_match "Did you mean?  @@does_exist", error.to_s
@@ -125,14 +125,14 @@ class VariableNameCheckTest < Test::Unit::TestCase
 
   def test_struct_name_error
     value = Struct.new(:does_exist).new
-    error = assert_raises(NameError){ value[:doesnt_exist] }
+    error = assert_raise(NameError){ value[:doesnt_exist] }
 
     assert_correction [:does_exist, :does_exist=], error.corrections
     assert_match "Did you mean?  does_exist", error.to_s
   end
 
   def test_exclude_typical_incorrect_suggestions
-    error = assert_raises(NameError){ foo }
+    error = assert_raise(NameError){ foo }
     assert_empty error.corrections
   end
 end

--- a/test/test_verbose_formatter.rb
+++ b/test/test_verbose_formatter.rb
@@ -10,7 +10,7 @@ class VerboseFormatterTest < Test::Unit::TestCase
   end
 
   def test_message
-    @error = assert_raises(NoMethodError){ 1.zeor? }
+    @error = assert_raise(NoMethodError){ 1.zeor? }
 
     assert_equal <<~MESSAGE.chomp, @error.message
       undefined method `zeor?' for 1:Integer

--- a/test/tree_spell/test_human_typo.rb
+++ b/test/tree_spell/test_human_typo.rb
@@ -17,7 +17,7 @@ class HumanTypoTest < Test::Unit::TestCase
   end
 
   def test_check_input
-    assert_raises(RuntimeError, "input length must be greater than 5 characters: tiny") do
+    assert_raise(RuntimeError, "input length must be greater than 5 characters: tiny") do
       TreeSpell::HumanTypo.new('tiny')
     end
   end


### PR DESCRIPTION
Two things are going wrong in the test suite for ruby core https://github.com/ruby/ruby/pull/2631. This attempts to fix both.

1. `assert_raises` throws a NoMethodError from within ruby core. Not sure why? It says to use `assert_raise` so that what I've gone and replaced everything with. Test suite still passes just fine so I imagine it's an alias in some versions of test/unit and not in others. Weird.
2. Due to the nature of how ruby core is running the tests, the bundled ruby did_you_mean is higher in the path than this gem's lib directory. So when you require did_you_mean, you actually end up testing the bundled version instead of the source code. Because of that, this commit changes the requires to be relative so that we're guaranteed to be requiring the correct code. There doesn't really appear to be a standard way to do this within Ruby core itself, it looks like it's different depending on the gem.

For the second point there, I'm not sure if that means there's something that should be done in Ruby core, but this will certainly fix it for just DYM.