### PR TITLE
More fixes

### DIFF
--- a/lib/did_you_mean/experimental/ivar_name_correction.rb
+++ b/lib/did_you_mean/experimental/ivar_name_correction.rb
@@ -36,6 +36,8 @@ module DidYouMean
 
         @location   = no_method_error.backtrace_locations.first
         @ivar_names = no_method_error.frame_binding.receiver.instance_variables
+
+        no_method_error.remove_instance_variable(:@frame_binding)
       end
 
       def corrections

--- a/test/core_ext/test_name_error_extension.rb
+++ b/test/core_ext/test_name_error_extension.rb
@@ -33,14 +33,16 @@ class NameErrorExtensionTest < Test::Unit::TestCase
   end
 
   def test_correctable_error_objects_are_dumpable
-   error = begin
-             File.open('did_you_mean.gemspec').sizee
-           rescue NoMethodError => e
-             e
-           end
+    error =
+      begin
+        Dir.chdir(__dir__) { File.open('test_name_error_extension.rb').sizee }
+      rescue NoMethodError => e
+        e
+      end
 
-   error.to_s
+    error.to_s
 
-   assert_equal "undefined method `sizee' for #<File:did_you_mean.gemspec>", Marshal.load(Marshal.dump(error)).original_message
+    assert_equal "undefined method `sizee' for #<File:test_name_error_extension.rb>",
+                 Marshal.load(Marshal.dump(error)).original_message
   end
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,18 +1,32 @@
 require 'test/unit'
 
-roots = [
-  File.expand_path('../lib/did_you_mean', __dir__), # source
-  File.expand_path('../../lib/did_you_mean', __dir__) # ruby core
-]
-  
-require_relative roots.detect { |file| File.file?("#{file}.rb") }
+module DidYouMean
+  module TestHelper
+    class << self
+      attr_reader :root
+    end
 
-puts "DidYouMean version: #{DidYouMean::VERSION}"
+    if File.file?(File.expand_path('../lib/did_you_mean.rb', __dir__))
+      # In this case we're being run from inside the gem, so we just want to
+      # require the root of the library
 
-module DidYouMean::TestHelper
-  def assert_correction(expected, array)
-    assert_equal Array(expected), array, "Expected #{array.inspect} to only include #{expected.inspect}"
+      @root = File.expand_path('../lib/did_you_mean', __dir__)
+      require_relative @root
+    else
+      # In this case we're being run from inside ruby core, and we want to
+      # include the experimental features in the test suite
+
+      @root = File.expand_path('../../lib/did_you_mean', __dir__)
+      require_relative @root
+      require_relative File.join(@root, 'experimental')
+    end
+
+    def assert_correction(expected, array)
+      assert_equal Array(expected), array, "Expected #{array.inspect} to only include #{expected.inspect}"
+    end
   end
 end
+
+puts "DidYouMean version: #{DidYouMean::VERSION}"
 
 Test::Unit::TestCase.include(DidYouMean::TestHelper)

--- a/test/test_verbose_formatter.rb
+++ b/test/test_verbose_formatter.rb
@@ -2,7 +2,7 @@ require 'helper'
 
 class VerboseFormatterTest < Test::Unit::TestCase
   def setup
-    require 'did_you_mean/verbose'
+    require_relative File.join(DidYouMean::TestHelper.root, 'verbose')
   end
 
   def teardown


### PR DESCRIPTION
Okay I think these are probably the last two fixes needed for ruby core. Here they are:

1. When requiring the verbose formatter, it was using an absolute require instead of a require_relative, which gets messed up within the ruby core infra. This changes the requirement to be relative and to use the root determined by the test helper.
2. When experimental is turned on, the NoMethodError class was holding onto the @frame_binding instance variable, which made it unable to be dumped by Marshal. It doesn't appear that we actually need that instance variable once we've pulled out the instance variables names, so we can get rid of it.