### PR TITLE
Exclude reserved words from suggestion to non-private call

### DIFF
--- a/lib/did_you_mean/spell_checkers/method_name_checker.rb
+++ b/lib/did_you_mean/spell_checkers/method_name_checker.rb
@@ -43,7 +43,9 @@ module DidYouMean
     end
 
     def corrections
-      @corrections ||= SpellChecker.new(dictionary: RB_RESERVED_WORDS + method_names).correct(method_name) - names_to_exclude
+      dictionary = method_names
+      dictionary = RB_RESERVED_WORDS + dictionary if @private_call
+      @corrections ||= SpellChecker.new(dictionary: dictionary).correct(method_name) - names_to_exclude
     end
 
     def method_names

--- a/test/spell_checking/test_method_name_check.rb
+++ b/test/spell_checking/test_method_name_check.rb
@@ -137,4 +137,11 @@ class MethodNameCheckTest < Test::Unit::TestCase
     assert_correction :yield, error.corrections
     assert_match "Did you mean?  yield", error.to_s
   end
+
+  def test_does_not_suggest_yield
+    error = assert_raise(NoMethodError) { 1.yeild }
+
+    assert_correction [], error.corrections
+    assert_not_match /Did you mean\? +yield/, error.to_s
+  end
 end


### PR DESCRIPTION
For example, a reserved word `yield` is suggested agains `1.yeild`, but reserved words cannot be after a dot.