### PR TITLE
Suggest require paths on LoadError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.5.0 (Next)
+
+ - Suggest require paths on LoadError ([#143](https://github.com/ruby/did_you_mean/pull/143))
+
 ## [v1.4.0](https://github.com/ruby/did_you_mean/tree/v1.4.0)
 
 _<sup>released at 2020-05-09 02:56:43 UTC</sup>_

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ hash.fetch(:fooo)
 #    Did you mean?  :foo
 ```
 
+### LoadError
+
+```ruby
+require 'net-http'
+# => LoadError (cannot load such file -- net-http)
+#    Did you mean?  net/http
+```
+
 ## Verbose Formatter
 
 This verbose formatter changes the error message format to take more lines/spaces so it'll be slightly easier to read the suggestions. This formatter can totally be used in any environment including production.

--- a/benchmark/require_path_checker.rb
+++ b/benchmark/require_path_checker.rb
@@ -1,0 +1,47 @@
+# frozen-string-literal: true
+#
+# Run the following command to run this script:
+#
+#   $ ruby --disable-did_you_mean benchmark/require_path_checker.rb
+#
+
+require_relative '../lib/did_you_mean/spell_checkers/require_path_checker'
+
+require 'benchmark/ips'
+
+Benchmark.ips do |x|
+  x.config(time: 10, warmup: 10)
+
+  exception_with_slash = begin
+                           require 'net/htto'
+                         rescue LoadError => error
+                           error
+                         end
+
+  exception_without_slash = begin
+                              require 'net-http'
+                            rescue LoadError => error
+                              error
+                            end
+
+  checker_for_path = DidYouMean::RequirePathChecker.new(exception_with_slash)
+  checker_for_file = DidYouMean::RequirePathChecker.new(exception_without_slash)
+
+  x.report "original (with a /)" do
+    checker_for_path.corrections
+  end
+
+  x.report "original (without /)" do
+    checker_for_file.corrections
+  end
+
+  #x.report "proposed (with a /)" do
+  #  checker_for_path.experiment
+  #end
+  #
+  #x.report "proposed (without /)" do
+  #  checker_for_file.experiment
+  #end
+
+  x.compare!
+end

--- a/lib/did_you_mean.rb
+++ b/lib/did_you_mean.rb
@@ -6,6 +6,7 @@ require_relative 'did_you_mean/spell_checkers/name_error_checkers'
 require_relative 'did_you_mean/spell_checkers/method_name_checker'
 require_relative 'did_you_mean/spell_checkers/key_error_checker'
 require_relative 'did_you_mean/spell_checkers/null_checker'
+require_relative 'did_you_mean/spell_checkers/require_path_checker'
 require_relative 'did_you_mean/formatters/plain_formatter'
 require_relative 'did_you_mean/tree_spell_checker'
 
@@ -95,6 +96,7 @@ module DidYouMean
   correct_error NameError, NameErrorCheckers
   correct_error KeyError, KeyErrorChecker
   correct_error NoMethodError, MethodNameChecker
+  correct_error LoadError, RequirePathChecker
 
   # Returns the currently set formatter. By default, it is set to +DidYouMean::Formatter+.
   def self.formatter

--- a/lib/did_you_mean/spell_checkers/require_path_checker.rb
+++ b/lib/did_you_mean/spell_checkers/require_path_checker.rb
@@ -1,0 +1,33 @@
+# frozen-string-literal: true
+
+require_relative "../spell_checker"
+require_relative "../tree_spell_checker"
+
+module DidYouMean
+  class RequirePathChecker
+    attr_reader :path
+
+    INITIAL_LOAD_PATH = $LOAD_PATH.dup.freeze
+    ENV_SPECIFIC_EXT  = ".#{RbConfig::CONFIG["DLEXT"]}"
+
+    private_constant :INITIAL_LOAD_PATH, :ENV_SPECIFIC_EXT
+
+    def self.requireables
+      @requireables ||= INITIAL_LOAD_PATH
+                          .flat_map {|path| Dir.glob("**/???*{.rb,#{ENV_SPECIFIC_EXT}}", base: path) }
+                          .map {|path| path.chomp!(".rb") || path.chomp!(ENV_SPECIFIC_EXT) }
+    end
+
+    def initialize(exception)
+      @path = exception.path
+    end
+
+    def corrections
+      threshold     = path.size * 2
+      dictionary    = self.class.requireables.reject {|str| str.size >= threshold }
+      spell_checker = path.include?("/") ? TreeSpellChecker : SpellChecker
+
+      spell_checker.new(dictionary: dictionary).correct(path)
+    end
+  end
+end

--- a/test/spell_checking/test_require_path_check.rb
+++ b/test/spell_checking/test_require_path_check.rb
@@ -1,0 +1,30 @@
+require_relative '../helper'
+
+class RequirePathCheckTest < Test::Unit::TestCase
+  include DidYouMean::TestHelper
+
+  def test_load_error_from_require_has_suggestions
+    error = assert_raise LoadError do
+              require 'open_struct'
+            end
+
+    assert_correction 'ostruct', error.corrections
+    assert_match "Did you mean?  ostruct", error.to_s
+  end
+
+  def test_load_error_from_require_for_nested_files_has_suggestions
+    error = assert_raise LoadError do
+              require 'net/htt'
+            end
+
+    assert_correction 'net/http', error.corrections
+    assert_match "Did you mean?  net/http", error.to_s
+
+    error = assert_raise LoadError do
+              require 'net-http'
+            end
+
+    assert_correction ['net/http', 'net/https'], error.corrections
+    assert_match "Did you mean?  net/http", error.to_s
+  end
+end


### PR DESCRIPTION
In response to https://bugs.ruby-lang.org/issues/16824, I'm adding a "did you mean?" to the `LoadError`. Here is an example of how it looks like:

```ruby
 require 'net-http'
 # => LoadError (cannot load such file -- net-http)
 #    Did you mean?  net/http
```

## Performance

Finding suggestions on a large app could negatively impact the performance of the `LoadError#message`. On a 8-year old Rails app, there are 12676 requirable files:

```ruby
DidYouMean::RequirePathChecker.requireables.size
# => 12676
```

And there is a benchmark:

```
Warming up --------------------------------------
 original (with a /)    25.000  i/100ms
original (without /)     8.000  i/100ms
Calculating -------------------------------------
 original (with a /)    262.268  (± 4.2%) i/s -      2.625k in  10.028352s
original (without /)     74.966  (±17.3%) i/s -    712.000  in  10.015199s

Comparison:
 original (with a /):      262.3 i/s
original (without /):       75.0 i/s - 3.50x  slower
```

So it would take roughly 13ms for e.g. `require 'open_struct'`  and 3.81ms for e.g. `net/htt`. The performance difference comes with the fact that DYM uses the tree spell checker (generally more accurate and faster for path names) if possible, but falls back to the traditional spell checker. I don't think this is a bad start.

There is another concern in finding requirable files being a bottleneck due to disk I/O in `Dir.glob`. There is room for improvement, but for now let's leave it there.

## Todos

 * [x] Write up more details
 * [x] Update README and CHANGELOG
 * [x] Add benchmark results
