### PR TITLE
Rescue failing corrections with an empty array

### DIFF
--- a/lib/did_you_mean/core_ext/name_error.rb
+++ b/lib/did_you_mean/core_ext/name_error.rb
@@ -15,7 +15,7 @@ module DidYouMean
     end
 
     def corrections
-      @corrections ||= spell_checker.corrections
+      @corrections ||= spell_checker.corrections rescue []
     end
 
     def spell_checker


### PR DESCRIPTION
If an error is raised in Correctable#to_s it is rescued and the super
method is called instead. If Correctable#corrections is called it should
be rescued as well and return an empty array.

This allows 3rd party gems to customize how suggestions are displayed:
```
   error = NameError.new("uninitialized constant Object")
   puts error.original_message
   puts "Did you mean:"
   puts error.corrections.join(", ")
```

I'm trying to use `#original_message` and `#corrections` in the Rails error pages (https://github.com/rails/rails/pull/39363), but calling `#corrections` sometimes fails while `#to_s` works (but it doesn't show the suggestions).