### PR TITLE
Show a code line where the error occurred

### DIFF
--- a/lib/did_you_mean.rb
+++ b/lib/did_you_mean.rb
@@ -87,6 +87,15 @@ module DidYouMean
   # Map of error types and spell checker objects.
   SPELL_CHECKERS = Hash.new(NullChecker)
 
+  def self.point_error(error_class)
+    error_class.prepend(Pointable) unless error_class < Pointable
+  end
+
+  point_error NameError
+  point_error KeyError
+  point_error NoMethodError
+  point_error TypeError
+
   # Adds +DidYouMean+ functionality to an error using a given spell checker
   def self.correct_error(error_class, spell_checker)
     SPELL_CHECKERS[error_class.name] = spell_checker

--- a/lib/did_you_mean/core_ext/name_error.rb
+++ b/lib/did_you_mean/core_ext/name_error.rb
@@ -8,7 +8,7 @@ module DidYouMean
       msg = super.dup
       suggestion = DidYouMean.formatter.message_for(corrections)
 
-      msg << suggestion if !msg.end_with?(suggestion)
+      msg << suggestion if !msg.include?(suggestion)
       msg
     rescue
       super
@@ -20,6 +20,39 @@ module DidYouMean
 
     def spell_checker
       SPELL_CHECKERS[self.class.to_s].new(self)
+    end
+  end
+
+  module Pointable
+    def to_s
+      msg = super.dup
+
+      locs = backtrace_locations
+      return msg unless locs
+
+      loc = locs.first
+      path = loc.absolute_path
+      nd_call = RubyVM::AbstractSyntaxTree.of(loc)
+      if path && nd_call
+        case nd_call.type
+        when :OP_ASGN1, :OP_ASGN2, :OP_ASGN_AND, :OP_ASGN_OR, :OP_CDECL, :CALL, :OPCALL, :FCALL, :VCALL, :QCALL
+          nd_recv = nd_call.children[0]
+          if nd_recv.is_a?(RubyVM::AbstractSyntaxTree::Node) && nd_call.last_lineno == nd_recv.last_lineno
+            beg_column = nd_recv.last_column
+            end_column = nd_call.last_column
+            marker = " " * beg_column + "^" * (end_column - beg_column)
+            line = File.foreach(path).drop(nd_call.last_lineno - 1).first
+            points = "\n\n#{line}#{marker}"
+            msg << points if line && !msg.include?(points)
+          end
+        end
+      end
+
+      msg
+
+    rescue Exception
+
+      msg
     end
   end
 end

--- a/test/test_verbose_formatter.rb
+++ b/test/test_verbose_formatter.rb
@@ -14,10 +14,14 @@ class VerboseFormatterTest < Test::Unit::TestCase
   def test_message
     @error = assert_raise(NoMethodError){ 1.zeor? }
 
-    assert_match <<~MESSAGE.strip, @error.message
-      undefined method `zeor?' for 1:Integer
-
-          Did you mean? zero?
-    MESSAGE
+    expected = /
+      undefined\smethod\s`zeor\?'\sfor\s1:Integer\n
+      \n
+      (?:\s\s\s\s@error\s=\sassert_raise\(NoMethodError\)\{\s1\.zeor\?\s\}\n
+      \s{43}\^\^\^\^\^\^\n
+      \n)?
+      \s\s\s\sDid\ you\ mean\?\ zero\?
+    /x
+    assert_match expected, @error.message
   end
 end


### PR DESCRIPTION
This changeset adds "Pointable" error message extension.

```
json = [[1]]
json.first.fisrt
```

```
err.rb:2:in `<main>': undefined method `fisrt' for [1]:Array (NoMethodError)

json.first.fisrt
          ^^^^^^
Did you mean?  first
```

This chagne depends upon https://bugs.ruby-lang.org/issues/17930 and
https://github.com/ruby/ruby/pull/4558 .