### PR TITLE
Let Correctable#original_message skip prepended method definitions

### DIFF
--- a/lib/did_you_mean/core_ext/name_error.rb
+++ b/lib/did_you_mean/core_ext/name_error.rb
@@ -1,7 +1,14 @@
 module DidYouMean
   module Correctable
+    SKIP_TO_S_FOR_SUPER_LOOKUP = true
+    private_constant :SKIP_TO_S_FOR_SUPER_LOOKUP
+
     def original_message
-      method(:to_s).super_method.call
+      meth = method(:to_s)
+      while meth.owner.const_defined?(:SKIP_TO_S_FOR_SUPER_LOOKUP)
+        meth = meth.super_method
+      end
+      meth.call
     end
 
     def to_s


### PR DESCRIPTION
Previously, DidYouMean::Correctable#original_message did
`method(:to_s).super_method.call` to call the original to_s method by
skipping Correctable#to_s.

I'm now creating a gem that prepends another to_s method to NameError,
which confuses the hack. An immediate solution is to replace it with
`method(:to_s).super_method.super_method.call` to skip the two methods.
But it is too ad-hoc.

This changeset uses more extensible approach and allow a prepended
module to declare that they should be skipped by defining a constant
named `SKIP_TO_S_FOR_SUPER_LOOKUP`.