### PR TITLE
Use String#include? instead of end_with? to avoid message duplication

### DIFF
--- a/lib/did_you_mean/core_ext/name_error.rb
+++ b/lib/did_you_mean/core_ext/name_error.rb
@@ -8,7 +8,7 @@ module DidYouMean
       msg = super.dup
       suggestion = DidYouMean.formatter.message_for(corrections)
 
-      msg << suggestion if !msg.end_with?(suggestion)
+      msg << suggestion if !msg.include?(suggestion)
       msg
     rescue
       super


### PR DESCRIPTION
Previously, did_you_mean used `msg.end_with?(suggestion)` to check if
its suggestion is already added.

I'm now creating a gem that also modifies Exception's message. This
breaks did_you_mean's duplication check.
This change makes the check use String#include? instead of end_with?.