### PR TITLE
Use assert_not_match "Did you mean?" for UncorrectableNameCheckTest

### DIFF
--- a/test/spell_checking/test_uncorrectable_name_check.rb
+++ b/test/spell_checking/test_uncorrectable_name_check.rb
@@ -10,6 +10,6 @@ class UncorrectableNameCheckTest < Test::Unit::TestCase
   end
 
   def test_message
-    assert_equal "Other name error", @error.message
+    assert_not_match /Did you mean\?/, @error.message
   end
 end


### PR DESCRIPTION
... instead of exact matching. I'm now creating a built-in gem that
modifies Exception's error message, so the expectation value is changed.

IMO, it is good to check that did_you_mean suggestion is NOT added in
the uncorrectable case.