### PR TITLE
Prevent "warning: ambiguity between regexp and two divisions"

### DIFF
--- a/test/spell_checking/test_uncorrectable_name_check.rb
+++ b/test/spell_checking/test_uncorrectable_name_check.rb
@@ -10,6 +10,6 @@ class UncorrectableNameCheckTest < Test::Unit::TestCase
   end
 
   def test_message
-    assert_not_match /Did you mean\?/, @error.message
+    assert_not_match(/Did you mean\?/, @error.message)
   end
 end


### PR DESCRIPTION
```
test/did_you_mean/spell_checking/test_uncorrectable_name_check.rb:13: warning: ambiguity between regexp and two divisions: wrap regexp in parentheses or add a space after `/' operator
```
http://rubyci.s3.amazonaws.com/ubuntu/ruby-master/log/20210630T033005Z.log.html.gz#test-all