### PR TITLE
Improve Ractor-compliance

### DIFF
--- a/lib/did_you_mean/core_ext/name_error.rb
+++ b/lib/did_you_mean/core_ext/name_error.rb
@@ -26,7 +26,7 @@ module DidYouMean
     end
 
     def spell_checker
-      SPELL_CHECKERS[self.class.to_s].new(self)
+      DidYouMean.spell_checkers_map[self.class.to_s].new(self)
     end
   end
 end

--- a/lib/did_you_mean/spell_checkers/name_error_checkers.rb
+++ b/lib/did_you_mean/spell_checkers/name_error_checkers.rb
@@ -17,4 +17,5 @@ module DidYouMean
       end.new(exception)
     end
   end
+  Ractor.make_shareable(NameErrorCheckers) if defined?(Ractor)
 end

--- a/lib/did_you_mean/spell_checkers/require_path_checker.rb
+++ b/lib/did_you_mean/spell_checkers/require_path_checker.rb
@@ -9,14 +9,22 @@ module DidYouMean
     attr_reader :path
 
     INITIAL_LOAD_PATH = $LOAD_PATH.dup.freeze
-    ENV_SPECIFIC_EXT  = ".#{RbConfig::CONFIG["DLEXT"]}"
+    ENV_SPECIFIC_EXT  = ".#{RbConfig::CONFIG["DLEXT"]}".freeze
 
     private_constant :INITIAL_LOAD_PATH, :ENV_SPECIFIC_EXT
 
-    def self.requireables
-      @requireables ||= INITIAL_LOAD_PATH
-                          .flat_map {|path| Dir.glob("**/???*{.rb,#{ENV_SPECIFIC_EXT}}", base: path) }
-                          .map {|path| path.chomp!(".rb") || path.chomp!(ENV_SPECIFIC_EXT) }
+    if defined?(Ractor)
+      def self.requireables
+        Ractor.current[:__DidYouMean_RequirePathChecker_requireables__] ||= INITIAL_LOAD_PATH
+          .flat_map {|path| Dir.glob("**/???*{.rb,#{ENV_SPECIFIC_EXT}}", base: path) }
+          .map {|path| path.chomp!(".rb") || path.chomp!(ENV_SPECIFIC_EXT) }
+      end
+    else
+      def self.requireables
+        @requireables ||= INITIAL_LOAD_PATH
+          .flat_map {|path| Dir.glob("**/???*{.rb,#{ENV_SPECIFIC_EXT}}", base: path) }
+          .map {|path| path.chomp!(".rb") || path.chomp!(ENV_SPECIFIC_EXT) }
+      end
     end
 
     def initialize(exception)

--- a/lib/did_you_mean/version.rb
+++ b/lib/did_you_mean/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module DidYouMean
   VERSION = "1.6.0-alpha"
 end


### PR DESCRIPTION
The did_you_mean library has some areas that are incompatible in Ractors. These can be fixed by freezing constants and avoiding class variables, and also making some of the hashes Ractor-local.