### PR TITLE
Remove exactly same name from corrections

### DIFF
--- a/lib/did_you_mean/spell_checker.rb
+++ b/lib/did_you_mean/spell_checker.rb
@@ -9,12 +9,12 @@ module DidYouMean
       @dictionary = dictionary
     end
 
-    def correct(input)
-      input     = normalize(input)
+    def correct(input_orig)
+      input     = normalize(input_orig)
       threshold = input.length > 3 ? 0.834 : 0.77
 
       words = @dictionary.select { |word| JaroWinkler.distance(normalize(word), input) >= threshold }
-      words.reject! { |word| input == word.to_s }
+      words.reject! { |word| input_orig.to_s == word.to_s }
       words.sort_by! { |word| JaroWinkler.distance(word.to_s, input) }
       words.reverse!
 

--- a/test/test_spell_checker.rb
+++ b/test/test_spell_checker.rb
@@ -10,6 +10,7 @@ class SpellCheckerTest < Test::Unit::TestCase
     assert_spell 'eval',  input: 'veal',  dictionary: ['email', 'fail', 'eval']
     assert_spell 'sub!',  input: 'suv!',  dictionary: ['sub', 'gsub', 'sub!']
     assert_spell 'sub',   input: 'suv',   dictionary: ['sub', 'gsub', 'sub!']
+    assert_spell 'Foo',   input: 'FOo',   dictionary: ['Foo', 'FOo']
 
     assert_spell %w(gsub! gsub),     input: 'gsuv!', dictionary: %w(sub gsub gsub!)
     assert_spell %w(sub! sub gsub!), input: 'ssub!', dictionary: %w(sub sub! gsub gsub!)


### PR DESCRIPTION
This PR removes the exactly same name from corrections.


# Problem

The corrections may include the input when the input contains capital characters.
For example:

* The dictionary is `Foo` and `FOo`
* The input is `FOo`
* Then the corrections will be `['Foo', 'FOo']`




# Solution

The cause is a wrong comparing. To reject the same name, it compares "normalized" input and the candidates. So if the candidates include the original `input`, it isn't rejected.

So this patch changes to compare the "original" input and the candidates.

# Note

By the way, I found this problem with `{__FILE__:}`, with the hash omission feature of Ruby 3.1-dev. https://bugs.ruby-lang.org/issues/14579
It displays the following error:


```console
$ ruby -e '{__FILE__:}' 
-e:1:in `<main>': undefined local variable or method `__FILE__' for main:Object (NameError)

{__FILE__:}
 ^^^^^^^^^
Did you mean?  __FILE__
               __LINE__
```

I think it is a super rare case and I'm not sure there are other reproduce code. So I'm not sure this patch affects the real users.