### PR TITLE
Fix typo in CHANGELOG.md about #164

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
   After:
   ```ruby
   DidYouMean::SpellChecker.new(dictionary: ['Method', 'MEthod']).correct("MEthod")
-  # => ['MEthod']
+  # => ['Method']
   ```
 
 ## [v1.5.0](https://github.com/ruby/did_you_mean/tree/v1.5.0)


### PR DESCRIPTION
The example actually returns `["Method"]` after the fix, but the changelog displays the wrong result.

```
$ ruby -Ilib -e p "DidYouMean::SpellChecker.new(dictionary: ['Method', 'MEthod']).correct('MEthod')"
["Method"]
```