### PR TITLE
Fix typo in CHANGELOG `DidYouMean::SPELL_CHECKERS`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ _<sup>released at 2020-12-22 13:22:35 UTC</sup>_
 #### Deprecations
 
 - Deprecate custom formatters to reduce complexity for Ractor support.
-- Deprecate access to the `DidYouMean::SPELL_CHECEKRS` constant for Ractor support.
+- Deprecate access to the `DidYouMean::SPELL_CHECKERS` constant for Ractor support.
 
 #### Features
 


### PR DESCRIPTION
This pull request fixes typo in CHANGELOG. 