### PR TITLE
Fix `frozen_string_literal is ignored after any tokens` warning.

### DIFF
--- a/lib/did_you_mean/formatters/verbose_formatter.rb
+++ b/lib/did_you_mean/formatters/verbose_formatter.rb
@@ -1,8 +1,9 @@
+# frozen-string-literal: true
+
 warn "`require 'did_you_mean/formatters/verbose_formatter'` is deprecated and falls back to the default formatter. "
 
 require_relative '../formatter'
 
-# frozen-string-literal: true
 module DidYouMean
   # For compatibility:
   VerboseFormatter = Formatter


### PR DESCRIPTION
```
did_you_mean/formatters/verbose_formatter.rb:5: warning: `frozen_string_literal' is ignored after any tokens
```