### PR TITLE
Fixed correction duplicates in VaribaleNameChecker

### DIFF
--- a/lib/did_you_mean/spell_checkers/name_error_checkers/variable_name_checker.rb
+++ b/lib/did_you_mean/spell_checkers/name_error_checkers/variable_name_checker.rb
@@ -79,7 +79,7 @@ module DidYouMean
     def corrections
       @corrections ||= SpellChecker
                      .new(dictionary: (RB_RESERVED_WORDS + lvar_names + method_names + ivar_names + cvar_names))
-                     .correct(name) - NAMES_TO_EXCLUDE[@name]
+                     .correct(name).uniq - NAMES_TO_EXCLUDE[@name]
     end
   end
 end

--- a/test/spell_checking/test_variable_name_check.rb
+++ b/test/spell_checking/test_variable_name_check.rb
@@ -137,4 +137,16 @@ class VariableNameCheckTest < Test::Unit::TestCase
     error = assert_raise(NameError){ foo }
     assert_empty error.corrections
   end
+
+  def test_exclude_duplicates_with_same_name
+    error = assert_raise(NameError) do
+      eval(<<~RUBY, binding, __FILE__, __LINE__)
+        bar = 1
+        def bar;end
+        zar
+      RUBY
+    end
+
+    assert_correction [:bar], error.corrections
+  end
 end


### PR DESCRIPTION
Fixed duplicates in corrections when passing method and variables with same name. Fixed #168 