### PR TITLE
Define Exception#detailed_message instead of clobbering #message

### DIFF
--- a/lib/did_you_mean/core_ext/name_error.rb
+++ b/lib/did_you_mean/core_ext/name_error.rb
@@ -1,24 +1,49 @@
 module DidYouMean
   module Correctable
-    SKIP_TO_S_FOR_SUPER_LOOKUP = true
-    private_constant :SKIP_TO_S_FOR_SUPER_LOOKUP
-
-    def original_message
-      meth = method(:to_s)
-      while meth.owner.const_defined?(:SKIP_TO_S_FOR_SUPER_LOOKUP)
-        meth = meth.super_method
+    if Exception.method_defined?(:detailed_message)
+      # just for compatibility
+      def original_message
+        # we cannot use alias here because
+        to_s
       end
-      meth.call
-    end
 
-    def to_s
-      msg = super.dup
-      suggestion = DidYouMean.formatter.message_for(corrections)
+      def detailed_message(highlight: true, did_you_mean: true, **)
+        msg = super.dup
 
-      msg << suggestion if !msg.include?(suggestion)
-      msg
-    rescue
-      super
+        return msg unless did_you_mean
+
+        suggestion = DidYouMean.formatter.message_for(corrections)
+
+        if highlight
+          suggestion = suggestion.gsub(/.+/) { "\e[1m" + $& + "\e[m" }
+        end
+
+        msg << suggestion
+        msg
+      rescue
+        super
+      end
+    else
+      SKIP_TO_S_FOR_SUPER_LOOKUP = true
+      private_constant :SKIP_TO_S_FOR_SUPER_LOOKUP
+
+      def original_message
+        meth = method(:to_s)
+        while meth.owner.const_defined?(:SKIP_TO_S_FOR_SUPER_LOOKUP)
+          meth = meth.super_method
+        end
+        meth.call
+      end
+
+      def to_s
+        msg = super.dup
+        suggestion = DidYouMean.formatter.message_for(corrections)
+
+        msg << suggestion if !msg.include?(suggestion)
+        msg
+      rescue
+        super
+      end
     end
 
     def corrections

--- a/test/core_ext/test_name_error_extension.rb
+++ b/test/core_ext/test_name_error_extension.rb
@@ -1,6 +1,8 @@
 require_relative '../helper'
 
 class NameErrorExtensionTest < Test::Unit::TestCase
+  include DidYouMean::TestHelper
+
   SPELL_CHECKERS = DidYouMean.spell_checkers
 
   class TestSpellChecker
@@ -20,8 +22,12 @@ class NameErrorExtensionTest < Test::Unit::TestCase
   end
 
   def test_message
-    assert_match(/Did you mean\?  does_exist/, @error.to_s)
-    assert_match(/Did you mean\?  does_exist/, @error.message)
+    if Exception.method_defined?(:detailed_message)
+      assert_match(/Did you mean\?  does_exist/, @error.detailed_message)
+    else
+      assert_match(/Did you mean\?  does_exist/, @error.to_s)
+      assert_match(/Did you mean\?  does_exist/, @error.message)
+    end
   end
 
   def test_to_s_does_not_make_disruptive_changes_to_error_message
@@ -29,8 +35,8 @@ class NameErrorExtensionTest < Test::Unit::TestCase
       raise NameError, "uninitialized constant Object"
     end
 
-    error.to_s
-    assert_equal 1, error.to_s.scan("Did you mean?").count
+    get_message(error)
+    assert_equal 1, get_message(error).scan("Did you mean?").count
   end
 
   def test_correctable_error_objects_are_dumpable
@@ -41,7 +47,7 @@ class NameErrorExtensionTest < Test::Unit::TestCase
         e
       end
 
-    error.to_s
+    get_message(error)
 
     assert_equal "undefined method `sizee' for #<File:test_name_error_extension.rb (closed)>",
                  Marshal.load(Marshal.dump(error)).original_message

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -29,5 +29,15 @@ module DidYouMean
     def assert_correction(expected, array)
       assert_equal Array(expected), array, "Expected #{array.inspect} to only include #{expected.inspect}"
     end
+
+    def get_message(err)
+      if err.respond_to?(:detailed_message)
+        err.detailed_message(highlight: false)
+      else
+        err.to_s
+      end
+    end
+
+    module_function :get_message
   end
 end

--- a/test/spell_checking/test_key_name_check.rb
+++ b/test/spell_checking/test_key_name_check.rb
@@ -8,11 +8,11 @@ class KeyNameCheckTest < Test::Unit::TestCase
 
     error = assert_raise(KeyError) { hash.fetch(:bax) }
     assert_correction ":bar", error.corrections
-    assert_match "Did you mean?  :bar", error.to_s
+    assert_match "Did you mean?  :bar", get_message(error)
 
     error = assert_raise(KeyError) { hash.fetch("fooo") }
     assert_correction %("foo"), error.corrections
-    assert_match %(Did you mean?  "foo"), error.to_s
+    assert_match %(Did you mean?  "foo"), get_message(error)
   end
 
   def test_corrects_hash_key_name_with_fetch_values
@@ -20,11 +20,11 @@ class KeyNameCheckTest < Test::Unit::TestCase
 
     error = assert_raise(KeyError) { hash.fetch_values("foo", :bar, :bax) }
     assert_correction ":bar", error.corrections
-    assert_match "Did you mean?  :bar", error.to_s
+    assert_match "Did you mean?  :bar", get_message(error)
 
     error = assert_raise(KeyError) { hash.fetch_values("foo", :bar, "fooo") }
     assert_correction %("foo"), error.corrections
-    assert_match %(Did you mean?  "foo"), error.to_s
+    assert_match %(Did you mean?  "foo"), get_message(error)
   end
 
   def test_correct_symbolized_hash_keys_with_string_value
@@ -32,13 +32,13 @@ class KeyNameCheckTest < Test::Unit::TestCase
 
     error = assert_raise(KeyError) { hash.fetch('foo_1') }
     assert_correction %(:foo_1), error.corrections
-    assert_match %(Did you mean?  :foo_1), error.to_s
+    assert_match %(Did you mean?  :foo_1), get_message(error)
   end
 
   def test_corrects_sprintf_key_name
     error = assert_raise(KeyError) { sprintf("%<foo>d", {fooo: 1}) }
     assert_correction ":fooo", error.corrections
-    assert_match "Did you mean?  :fooo", error.to_s
+    assert_match "Did you mean?  :fooo", get_message(error)
   end
 
   def test_corrects_env_key_name
@@ -46,7 +46,7 @@ class KeyNameCheckTest < Test::Unit::TestCase
     ENV["BAR"] = "2"
     error = assert_raise(KeyError) { ENV.fetch("BAX") }
     assert_correction %("BAR"), error.corrections
-    assert_match %(Did you mean?  "BAR"), error.to_s
+    assert_match %(Did you mean?  "BAR"), get_message(error)
   ensure
     ENV.delete("FOO")
     ENV.delete("BAR")

--- a/test/spell_checking/test_method_name_check.rb
+++ b/test/spell_checking/test_method_name_check.rb
@@ -41,28 +41,28 @@ class MethodNameCheckTest < Test::Unit::TestCase
     error = assert_raise(NoMethodError){ @user.flrst_name }
 
     assert_correction :first_name, error.corrections
-    assert_match "Did you mean?  first_name",  error.to_s
+    assert_match "Did you mean?  first_name",  get_message(error)
   end
 
   def test_corrections_include_private_method
     error = assert_raise(NoMethodError){ @user.friend }
 
     assert_correction :friends, error.corrections
-    assert_match "Did you mean?  friends", error.to_s
+    assert_match "Did you mean?  friends", get_message(error)
   end
 
   def test_corrections_include_method_from_module
     error = assert_raise(NoMethodError){ @user.fr0m_module }
 
     assert_correction :from_module, error.corrections
-    assert_match "Did you mean?  from_module", error.to_s
+    assert_match "Did you mean?  from_module", get_message(error)
   end
 
   def test_corrections_include_class_method
     error = assert_raise(NoMethodError){ User.l0ad }
 
     assert_correction :load, error.corrections
-    assert_match "Did you mean?  load", error.to_s
+    assert_match "Did you mean?  load", get_message(error)
   end
 
   def test_private_methods_should_not_be_suggested
@@ -77,7 +77,7 @@ class MethodNameCheckTest < Test::Unit::TestCase
     error = assert_raise(NoMethodError){ @user.call_incorrect_private_method }
 
     assert_correction :raise, error.corrections
-    assert_match "Did you mean?  raise", error.to_s
+    assert_match "Did you mean?  raise", get_message(error)
   end
 
   def test_exclude_methods_on_nil
@@ -104,7 +104,7 @@ class MethodNameCheckTest < Test::Unit::TestCase
       end
     end
 
-    assert_equal 1, error.to_s.scan(/Did you mean/).count
+    assert_equal 1, get_message(error).scan(/Did you mean/).count
   end
 
   def test_does_not_append_suggestions_three_times
@@ -116,7 +116,7 @@ class MethodNameCheckTest < Test::Unit::TestCase
       end
     end
 
-    assert_equal 1, error.to_s.scan(/Did you mean/).count
+    assert_equal 1, get_message(error).scan(/Did you mean/).count
   end
 
   def test_suggests_corrections_on_nested_error
@@ -128,20 +128,20 @@ class MethodNameCheckTest < Test::Unit::TestCase
       end
     end
 
-    assert_equal 1, error.to_s.scan(/Did you mean/).count
+    assert_equal 1, get_message(error).scan(/Did you mean/).count
   end
 
   def test_suggests_yield
     error = assert_raise(NoMethodError) { yeild(1) }
 
     assert_correction :yield, error.corrections
-    assert_match "Did you mean?  yield", error.to_s
+    assert_match "Did you mean?  yield", get_message(error)
   end
 
   def test_does_not_suggest_yield
     error = assert_raise(NoMethodError) { 1.yeild }
 
     assert_correction [], error.corrections
-    assert_not_match(/Did you mean\? +yield/, error.to_s)
+    assert_not_match(/Did you mean\? +yield/, get_message(error))
   end if RUBY_ENGINE != "jruby"
 end

--- a/test/spell_checking/test_pattern_key_name_check.rb
+++ b/test/spell_checking/test_pattern_key_name_check.rb
@@ -15,6 +15,6 @@ class PatternKeyNameCheckTest < Test::Unit::TestCase
     end
 
     assert_correction ":foo", error.corrections
-    assert_match "Did you mean?  :foo", error.to_s
+    assert_match "Did you mean?  :foo", get_message(error)
   end
 end

--- a/test/spell_checking/test_require_path_check.rb
+++ b/test/spell_checking/test_require_path_check.rb
@@ -11,7 +11,7 @@ class RequirePathCheckTest < Test::Unit::TestCase
             end
 
     assert_correction 'ostruct', error.corrections
-    assert_match "Did you mean?  ostruct", error.to_s
+    assert_match "Did you mean?  ostruct", get_message(error)
   end
 
   def test_load_error_from_require_for_nested_files_has_suggestions
@@ -20,13 +20,13 @@ class RequirePathCheckTest < Test::Unit::TestCase
             end
 
     assert_correction 'net/http', error.corrections
-    assert_match "Did you mean?  net/http", error.to_s
+    assert_match "Did you mean?  net/http", get_message(error)
 
     error = assert_raise LoadError do
               require 'net-http'
             end
 
     assert_correction ['net/http', 'net/https'], error.corrections
-    assert_match "Did you mean?  net/http", error.to_s
+    assert_match "Did you mean?  net/http", get_message(error)
   end
 end

--- a/test/spell_checking/test_variable_name_check.rb
+++ b/test/spell_checking/test_variable_name_check.rb
@@ -39,7 +39,7 @@ class VariableNameCheckTest < Test::Unit::TestCase
     end
 
     assert_correction :first_name, error.corrections
-    assert_match "Did you mean?  first_name", error.to_s
+    assert_match "Did you mean?  first_name", get_message(error)
   end
 
   def test_corrections_include_method_from_module
@@ -48,7 +48,7 @@ class VariableNameCheckTest < Test::Unit::TestCase
     end
 
     assert_correction :from_module, error.corrections
-    assert_match "Did you mean?  from_module", error.to_s
+    assert_match "Did you mean?  from_module", get_message(error)
   end
 
   def test_corrections_include_local_variable_name
@@ -57,7 +57,7 @@ class VariableNameCheckTest < Test::Unit::TestCase
       error = (eprson rescue $!) # Do not use @assert_raise here as it changes a scope.
 
       assert_correction :person, error.corrections
-      assert_match "Did you mean?  person", error.to_s
+      assert_match "Did you mean?  person", get_message(error)
     end
   end
 
@@ -81,30 +81,30 @@ class VariableNameCheckTest < Test::Unit::TestCase
     end
 
     assert_correction :false, false_error.corrections
-    assert_match "Did you mean?  false", false_error.to_s
+    assert_match "Did you mean?  false", get_message(false_error)
 
     assert_correction :true, true_error.corrections
-    assert_match "Did you mean?  true", true_error.to_s
+    assert_match "Did you mean?  true", get_message(true_error)
 
     assert_correction :nil, nil_error.corrections
-    assert_match "Did you mean?  nil", nil_error.to_s
+    assert_match "Did you mean?  nil", get_message(nil_error)
 
     assert_correction :__FILE__, file_error.corrections
-    assert_match "Did you mean?  __FILE__", file_error.to_s
+    assert_match "Did you mean?  __FILE__", get_message(file_error)
   end
 
   def test_suggests_yield
     error = assert_raise(NameError) { yeild }
 
     assert_correction :yield, error.corrections
-    assert_match "Did you mean?  yield", error.to_s
+    assert_match "Did you mean?  yield", get_message(error)
   end
 
   def test_corrections_include_instance_variable_name
     error = assert_raise(NameError){ @user.to_s }
 
     assert_correction :@email_address, error.corrections
-    assert_match "Did you mean?  @email_address", error.to_s
+    assert_match "Did you mean?  @email_address", get_message(error)
   end
 
   def test_corrections_include_private_method
@@ -113,7 +113,7 @@ class VariableNameCheckTest < Test::Unit::TestCase
     end
 
     assert_correction :cia_codename, error.corrections
-    assert_match "Did you mean?  cia_codename",  error.to_s
+    assert_match "Did you mean?  cia_codename",  get_message(error)
   end
 
   @@does_exist = true
@@ -122,7 +122,7 @@ class VariableNameCheckTest < Test::Unit::TestCase
     error = assert_raise(NameError){ @@doesnt_exist }
 
     assert_correction :@@does_exist, error.corrections
-    assert_match "Did you mean?  @@does_exist", error.to_s
+    assert_match "Did you mean?  @@does_exist", get_message(error)
   end
 
   def test_struct_name_error
@@ -130,7 +130,7 @@ class VariableNameCheckTest < Test::Unit::TestCase
     error = assert_raise(NameError){ value[:doesnt_exist] }
 
     assert_correction [:does_exist, :does_exist=], error.corrections
-    assert_match "Did you mean?  does_exist", error.to_s
+    assert_match "Did you mean?  does_exist", get_message(error)
   end
 
   def test_exclude_typical_incorrect_suggestions

--- a/test/test_ractor_compatibility.rb
+++ b/test/test_ractor_compatibility.rb
@@ -34,7 +34,7 @@ class RactorCompatibilityTest < Test::Unit::TestCase
             }.take
 
     assert_correction ":bar", error.corrections
-    assert_match "Did you mean?  :bar", error.to_s
+    assert_match "Did you mean?  :bar", get_message(error)
   end
 
   def test_method_name_suggestion_works_in_ractor
@@ -48,7 +48,7 @@ class RactorCompatibilityTest < Test::Unit::TestCase
             }.take
 
     assert_correction :to_s, error.corrections
-    assert_match "Did you mean?  to_s",  error.to_s
+    assert_match "Did you mean?  to_s",  get_message(error)
   end
 
   if defined?(::NoMatchingPatternKeyError)
@@ -67,7 +67,7 @@ class RactorCompatibilityTest < Test::Unit::TestCase
               }.take
 
       assert_correction ":foo", error.corrections
-      assert_match "Did you mean?  :foo", error.to_s
+      assert_match "Did you mean?  :foo", get_message(error)
     end
   end
 
@@ -97,6 +97,6 @@ class RactorCompatibilityTest < Test::Unit::TestCase
     }.take
 
     assert_correction :in_ractor, error.corrections
-    assert_match "Did you mean?  in_ractor", error.to_s
+    assert_match "Did you mean?  in_ractor", get_message(error)
   end
 end


### PR DESCRIPTION
This changeset lets DidYouMean::Correctable to use #detailed_message,
which is Ruby 3.2's more dedicated way to show additional error
information like did_you_mean and error_highlight.

There are some problems with the approach of overriding #message.
One is that the approach breaks a test that checks a return value
of #message. I actually faced this kind of issues in real-world
applications when I was implementing error_highlight with the same
approach as did_you_mean.
See https://github.com/minitest/minitest/pull/880 for example.

For this reason, error_highlight enhances only NameError.
The support of other error types such as TypeError and ArgumentError is
currently disabled because it breaks more tests:
https://github.com/ruby/error_highlight/blob/f88b6fab2ff34559a0f08d019d574dbb52426a20/lib/error_highlight/core_ext.rb#L49-L52

I believe #detailed_message will solve the issue.
I want did_you_mean and error_highlight to use the new API instead of
clobbering #message method.
See https://bugs.ruby-lang.org/issues/18564 for detail.