### PR TITLE
Do not suggest #name= for #name and vice versa

### DIFF
--- a/lib/did_you_mean/spell_checkers/method_name_checker.rb
+++ b/lib/did_you_mean/spell_checkers/method_name_checker.rb
@@ -59,6 +59,13 @@ module DidYouMean
         method_names = receiver.methods + receiver.singleton_methods
         method_names += receiver.private_methods if @private_call
         method_names.uniq!
+        # Assume that people trying to use a writer are not interested in a reader
+        # and vice versa
+        if method_name =~ /=\Z/
+          method_names.select!{|name| name =~ /=\Z/}
+        else
+          method_names.reject!{|name| name =~ /=\Z/}
+        end
         method_names
       else
         []

--- a/lib/did_you_mean/spell_checkers/method_name_checker.rb
+++ b/lib/did_you_mean/spell_checkers/method_name_checker.rb
@@ -61,10 +61,10 @@ module DidYouMean
         method_names.uniq!
         # Assume that people trying to use a writer are not interested in a reader
         # and vice versa
-        if method_name =~ /=\Z/
-          method_names.select!{|name| name =~ /=\Z/}
+        if method_name.match?(/=\Z/)
+          method_names.select! { |name| name.match?(/=\Z/) }
         else
-          method_names.reject!{|name| name =~ /=\Z/}
+          method_names.reject! { |name| name.match?(/=\Z/) }
         end
         method_names
       else

--- a/test/spell_checking/test_method_name_check.rb
+++ b/test/spell_checking/test_method_name_check.rb
@@ -4,6 +4,8 @@ class MethodNameCheckTest < Test::Unit::TestCase
   include DidYouMean::TestHelper
 
   class User
+    attr_writer :writer
+    attr_reader :reader
     def friends; end
     def first_name; end
     def descendants; end
@@ -144,4 +146,20 @@ class MethodNameCheckTest < Test::Unit::TestCase
     assert_correction [], error.corrections
     assert_not_match(/Did you mean\? +yield/, get_message(error))
   end if RUBY_ENGINE != "jruby"
+
+  # Do not suggest `name=` for `name`
+  def test_does_not_suggest_writer
+    error = assert_raise(NoMethodError) { @user.writer }
+
+    assert_correction [], error.corrections
+    assert_not_match(/Did you mean\?  writer=/, get_message(error))
+  end
+
+  # Do not suggest `name` for `name=`
+  def test_does_not_suggest_reader
+    error = assert_raise(NoMethodError) { @user.reader = 1 }
+
+    assert_correction [], error.corrections
+    assert_not_match(/Did you mean\?  reader/, get_message(error))
+  end
 end


### PR DESCRIPTION
A recent [discussion on Hacker News](https://news.ycombinator.com/item?id=33792874) reminded me of a particular type of suggestion that seems always irrelevant and potentially confusing. That would be suggesting `#foo` when someone calls `obj.foo = 1` or `#foo=` when someone calls `obj.foo`. I have actually seen inexperienced Rubyists read the message, scratch their heads, and try `obj.foo(1)` before moving on to their next idea.

Example:

```
3.1.2 :005 > book.title = "Programming Ruby"
(irb):5:in `<main>': undefined method `title=' for #<Book:0x00007f6b8842d650> (NoMethodError)
Did you mean?  title      
```

This is a fairly brute force implementation -- if the missing method name ends with =, only suggest methods that do, and vice versa. A more nuanced approach would be just to exclude the exact method name with = added or removed, as the case may be. I'm happy to spend some more time on it if the general proposal is welcome.