### PR TITLE
Support the new message format of NameError in Ruby 3.3

### DIFF
--- a/test/core_ext/test_name_error_extension.rb
+++ b/test/core_ext/test_name_error_extension.rb
@@ -49,7 +49,7 @@ class NameErrorExtensionTest < Test::Unit::TestCase
 
     get_message(error)
 
-    assert_equal "undefined method `sizee' for #<File:test_name_error_extension.rb (closed)>",
-                 Marshal.load(Marshal.dump(error)).original_message
+    assert_match(/^undefined method `sizee' for /,
+                 Marshal.load(Marshal.dump(error)).original_message)
   end
 end


### PR DESCRIPTION
This change accepts the following change of the message of NameError in a test.

https://bugs.ruby-lang.org/issues/18285#note-37

```
old: undefined method `sizee' for #<File:...>
new: undefined method `sizee' for an instance of File
```