### PR TITLE
Removed deprecated constants for Ruby 3.4

### DIFF
--- a/lib/did_you_mean.rb
+++ b/lib/did_you_mean.rb
@@ -113,30 +113,6 @@ module DidYouMean
   correct_error LoadError, RequirePathChecker if RUBY_VERSION >= '2.8.0'
   correct_error NoMatchingPatternKeyError, PatternKeyNameChecker if defined?(::NoMatchingPatternKeyError)
 
-  # TODO: Remove on the 3.4 development start:
-  class DeprecatedMapping # :nodoc:
-    def []=(key, value)
-      warn "Calling `DidYouMean::SPELL_CHECKERS[#{key.to_s}] = #{value.to_s}' has been deprecated. " \
-           "Please call `DidYouMean.correct_error(#{key.to_s}, #{value.to_s})' instead."
-
-      DidYouMean.correct_error(key, value)
-    end
-
-    def merge!(hash)
-      warn "Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. " \
-           "Please call `DidYouMean.correct_error(error_name, spell_checker)' instead."
-
-      hash.each do |error_class, spell_checker|
-        DidYouMean.correct_error(error_class, spell_checker)
-      end
-    end
-  end
-
-  # TODO: Remove on the 3.4 development start:
-  SPELL_CHECKERS = DeprecatedMapping.new
-  deprecate_constant :SPELL_CHECKERS
-  private_constant :DeprecatedMapping
-
   # Returns the currently set formatter. By default, it is set to +DidYouMean::Formatter+.
   def self.formatter
     if defined?(Ractor)


### PR DESCRIPTION
It's for Ruby 3.4.

@yuki24 Can we release 1.7.0 with this change?