### PR TITLE
Switch to use ostruct to open3 with suggestion test

### DIFF
--- a/test/spell_checking/test_require_path_check.rb
+++ b/test/spell_checking/test_require_path_check.rb
@@ -7,11 +7,11 @@ class RequirePathCheckTest < Test::Unit::TestCase
 
   def test_load_error_from_require_has_suggestions
     error = assert_raise LoadError do
-              require 'open_struct'
+              require 'open'
             end
 
-    assert_correction 'ostruct', error.corrections
-    assert_match "Did you mean?  ostruct", get_message(error)
+    assert_correction 'open3', error.corrections
+    assert_match "Did you mean?  open3", get_message(error)
   end
 
   def test_load_error_from_require_for_nested_files_has_suggestions


### PR DESCRIPTION
from https://bugs.ruby-lang.org/issues/20309

`ostruct` is will be bundled gems at Ruby 3.5. It means we can't load `ostruct` in ruby/ruby repository. I switched that to `open3` for similar usecase.