### PR TITLE
Fix a few inconsistencies in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,13 @@ no_method_error = begin
                   end
 
 no_method_error.message
-# => NoMethodError (undefined method `zeor?' for 1:Integer)
-#    Did you mean?  zero?
+# => "undefined method 'zeor?' for an instance of Integer"
 
 no_method_error.original_message
-# => NoMethodError (undefined method `zeor?' for 1:Integer)
+# => "undefined method 'zeor?' for an instance of Integer"
+
+no_method_error.detailed_message(highlight: false)
+# => "undefined method 'zeor?' for an instance of Integer (NoMethodError)\nDid you mean?  zero?"
 ```
 
 ## Benchmarking


### PR DESCRIPTION
### Detail

```ruby
# Ruby 3.4.9

no_method_error = begin
                    1.zeor?
                  rescue NoMethodError => error
                    error
                  end

no_method_error.message
# => "undefined method 'zeor?' for an instance of Integer"

no_method_error.original_message
# => "undefined method 'zeor?' for an instance of Integer"

no_method_error.detailed_message(highlight: false)
# => "undefined method 'zeor?' for an instance of Integer (NoMethodError)\nDid you mean?  zero?"

Exception.method_defined?(:detailed_message)
# => true
```
https://github.com/ruby/did_you_mean/blob/6740bdcb2844541b46f5244c21adea8386a23607/lib/did_you_mean/core_ext/name_error.rb
